### PR TITLE
feat: add support for createConditions instances in having method

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -12,6 +12,7 @@ import {
   SQLBuilderToSQLInputOptions,
   SQLBuilderToSQLOptions,
   SQLBuilderConditionInputPattern,
+  SQLBuilderConditionsPort,
   SQLBuilderBindingValue,
   SQLBuilderJoinDirection
 } from './types'
@@ -73,8 +74,25 @@ export class SQLBuilder implements SQLBuilderPort {
     return this
   }
 
-  having(...args: SQLBuilderConditionInputPattern): this {
-    this.conditions_having.and(...args)
+  having(conditions: SQLBuilderConditionsPort): this
+  having(field: SQLBuilderField, value: any): this
+  having(field: SQLBuilderField, operator: string, value: any): this
+  having(
+    conditionsOrField: SQLBuilderConditionsPort | SQLBuilderField,
+    operatorOrValue?: any,
+    value?: any
+  ): this {
+    if (typeof conditionsOrField === 'object' && 'and' in conditionsOrField) {
+      // SQLBuilderConditionsPortの場合
+      this.conditions_having.add('and', conditionsOrField)
+      return this
+    }
+    // 通常の条件の場合
+    if (value !== undefined) {
+      this.conditions_having.and(conditionsOrField as SQLBuilderField, operatorOrValue, value)
+    } else {
+      this.conditions_having.and(conditionsOrField as SQLBuilderField, operatorOrValue)
+    }
     return this
   }
 

--- a/src/specs/builder.spec.ts
+++ b/src/specs/builder.spec.ts
@@ -548,6 +548,25 @@ describe('builder', () => {
         )
         expect(bindings).to.be.eql([10])
       })
+
+      describe('conditions instance', () => {
+        it('"SELECT age, COUNT(*) AS value FROM users GROUP BY age HAVING value > ? OR value < ?", [10, 2]', () => {
+          const conditions = createConditions()
+            .and('value', '>', 10)
+            .or('value', '<', 2)
+          const [sql, bindings] = builder
+            .from('users')
+            .column('age')
+            .column(unescape('COUNT(*)'), 'value')
+            .groupBy('age')
+            .having(conditions)
+            .toSQL()
+          expect(sql).to.be.eql(
+            'SELECT\n  age,\n  COUNT(*) AS value\nFROM\n  users\nGROUP BY\n  age\nHAVING\n  ((value > ?)\n  OR (value < ?))'
+          )
+          expect(bindings).to.be.eql([10, 2])
+        })
+      })
     })
 
     describe('.orderBy', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,6 +346,17 @@ export interface SQLBuilderPort {
    */
   where(conditions: SQLBuilderConditionsPort): this
   /**
+   * Specified having condition using conditions instance.
+   *
+   * ```typescript
+   * const conditions = createConditions().and('value', '>', 10).or('value', '<', 2)
+   * builder.having(conditions)
+   * ```
+   *
+   * @param conditions
+   */
+  having(conditions: SQLBuilderConditionsPort): this
+  /**
    * Specified having condition.
    *
    * ```typescript


### PR DESCRIPTION
## Summary
- Add support for using `createConditions()` instances in `having()` method
- Enables complex conditional logic in HAVING clauses with AND/OR combinations
- Maintains backward compatibility with existing having syntax

## Changes
- Added `having(conditions: SQLBuilderConditionsPort)` overload to interface
- Implemented conditions instance support in `SQLBuilder.having` method
- Added comprehensive test case for having clause with conditions

## Example Usage
```typescript
import { createBuilder, createConditions, unescape } from 'coral-sql'

const havingConditions = createConditions()
  .and('value', '>', 10)
  .or('value', '<', 2)

const [sql, bindings] = createBuilder()
  .from('users')
  .column('age')
  .column(unescape('COUNT(*)'), 'value')
  .groupBy('age')
  .having(havingConditions)  // Now supported!
  .toSQL()

// Generates: HAVING ((value > ?) OR (value < ?))
```

## Test plan
- [x] All existing tests pass
- [x] New test case for conditions instance usage
- [x] Lint checks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)