### PR TITLE
feat: enhance caseWhen.when() to support same input patterns as where()

### DIFF
--- a/src/specs/case-when.spec.ts
+++ b/src/specs/case-when.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
 import {
-  createBuilder,
   caseWhen,
   createConditions,
   unescape,

--- a/src/specs/case-when.spec.ts
+++ b/src/specs/case-when.spec.ts
@@ -4,6 +4,7 @@ import {
   caseWhen,
   createConditions,
   unescape,
+  is_not_null,
   SQLBuilder,
   SQLBuilderPort
 } from '../../dist'
@@ -186,6 +187,23 @@ describe('caseWhen() function', () => {
         'SELECT\n  (CASE WHEN "status" = ? THEN ? ELSE ? END)\nFROM\n  "users"'
       )
       expect(bindings).to.be.eql(['active', 'Active', 'Inactive'])
+    })
+  })
+
+  describe('with is_not_null() and is_null() functions', () => {
+    it('Using is_not_null() as condition expression', () => {
+      const [sql, bindings] = builder
+        .from('users')
+        .column(
+          caseWhen()
+            .when('email', is_not_null()).then('Has Email')
+            .else('No Email')
+        )
+        .toSQL()
+      expect(sql).to.be.eql(
+        'SELECT\n  (CASE WHEN `email` IS NOT NULL THEN ? ELSE ? END)\nFROM\n  `users`'
+      )
+      expect(bindings).to.be.eql(['Has Email', 'No Email'])
     })
   })
 

--- a/src/specs/case-when.spec.ts
+++ b/src/specs/case-when.spec.ts
@@ -201,7 +201,7 @@ describe('caseWhen() function', () => {
         )
         .toSQL()
       expect(sql).to.be.eql(
-        'SELECT\n  (CASE WHEN `email` IS NOT NULL THEN ? ELSE ? END)\nFROM\n  `users`'
+        'SELECT\n  (CASE WHEN (`email` IS NOT NULL) THEN ? ELSE ? END)\nFROM\n  `users`'
       )
       expect(bindings).to.be.eql(['Has Email', 'No Email'])
     })


### PR DESCRIPTION
## Summary
- Enhanced `caseWhen().when()` method to accept the same variety of input patterns as the `where()` method
- Added support for field + expression combinations like `when('field', is_not_null())`
- Improved API consistency across the SQLBuilder interface

## Changes
- Added support for `SQLBuilderConditionInputPattern` in `when()` method
- Enhanced type definitions to handle new condition formats including `{ field: string; expression: SQLBuilderConditionExpressionPort }`
- Updated `toSQL()` method to properly handle field + expression combinations
- Added comprehensive test coverage for `is_not_null()` usage in case-when expressions

## Test plan
- ✅ All existing case-when tests continue to pass
- ✅ New test added for `is_not_null()` functionality
- ✅ TypeScript compilation succeeds
- ✅ Maintains backward compatibility with existing usage patterns

## Usage Examples
```typescript
// Now supported: field + expression pattern
caseWhen().when('ui.id', is_not_null()).then('active').else('inactive')

// Still supported: traditional patterns  
caseWhen().when('status', '=', 'active').then('Active').else('Inactive')
caseWhen().when('status', 'active').then('Active').else('Inactive')
caseWhen().when(createConditions().and('age', '>=', 18)).then('Adult').else('Minor')
```

🤖 Generated with [Claude Code](https://claude.ai/code)