### PR TITLE
feat!: rename caseWhen to case_when for consistent naming convention

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,11 @@ import {
 } from './types'
 import { unescape } from './utils/escape'
 import { exists, not_exists } from './utils/exists'
-import { caseWhen, coalesce, json_array_aggregate, json_object } from './utils/json'
+import { case_when, coalesce, json_array_aggregate, json_object } from './utils/json'
 import { is_not_null, is_null } from './utils/null'
 
 export {
-  caseWhen,
+  case_when,
   coalesce,
   exists,
   Field,

--- a/src/specs/case-when.spec.ts
+++ b/src/specs/case-when.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import {
-  caseWhen,
+  case_when,
   createConditions,
   unescape,
   is_not_null,
@@ -8,7 +8,7 @@ import {
   SQLBuilderPort
 } from '../../dist'
 
-describe('caseWhen() function', () => {
+describe('case_when() function', () => {
   let builder: SQLBuilderPort
   let postgresqlBuilder: SQLBuilderPort
   
@@ -22,7 +22,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('status', '=', 'active').then('Active User')
             .else('Inactive User')
         )
@@ -37,7 +37,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('status', '=', 'active').then('Active')
             .when('status', '=', 'pending').then('Pending')
             .when('status', '=', 'suspended').then('Suspended')
@@ -56,7 +56,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users', 'u')
         .column(
-          caseWhen()
+          case_when()
             .when('u.status', '=', 'active').then('Active')
             .else('Inactive')
         )
@@ -73,7 +73,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('orders')
         .column(
-          caseWhen()
+          case_when()
             .when('amount', '>', 1000).then('High Value')
             .when('amount', '>', 100).then('Medium Value')
             .else('Low Value')
@@ -89,7 +89,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('email', '=', null as any).then('No Email')
             .else('Has Email')
         )
@@ -104,7 +104,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('email', '!=', null as any).then('Has Email')
             .else('No Email')
         )
@@ -125,7 +125,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when(conditions).then('Adult Active User')
             .else('Other')
         )
@@ -142,7 +142,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('status', '=', 'active').then(unescape('UPPER(name)'))
             .else('Unknown')
         )
@@ -159,7 +159,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('status', '=', 'active').then('Active')
             .else('Inactive'),
           'status_label'
@@ -177,7 +177,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = postgresqlBuilder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('status', '=', 'active').then('Active')
             .else('Inactive')
         )
@@ -194,7 +194,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('email', is_not_null()).then('Has Email')
             .else('No Email')
         )
@@ -209,13 +209,13 @@ describe('caseWhen() function', () => {
   describe('error handling', () => {
     it('Should throw error when then() called without when()', () => {
       expect(() => {
-        caseWhen().then('value')
+        case_when().then('value')
       }).to.throw('then() must be called after when()')
     })
 
     it('Should throw error when else() called with pending condition', () => {
       expect(() => {
-        caseWhen()
+        case_when()
           .when('status', '=', 'active')
           .else('Default')
       }).to.throw('Cannot call else() with pending when() condition. Call then() first.')
@@ -223,7 +223,7 @@ describe('caseWhen() function', () => {
 
     it('Should throw error when toSQL() called with incomplete condition', () => {
       expect(() => {
-        caseWhen()
+        case_when()
           .when('status', '=', 'active')
           .toSQL()
       }).to.throw('Incomplete case expression. Missing then() call.')
@@ -235,7 +235,7 @@ describe('caseWhen() function', () => {
       const [sql, bindings] = builder
         .from('users')
         .column(
-          caseWhen()
+          case_when()
             .when('status', '=', 'active').then('Active User')
         )
         .toSQL()

--- a/src/specs/json.spec.ts
+++ b/src/specs/json.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import {
   createBuilder,
-  caseWhen,
   coalesce,
   json_array_aggregate,
   json_object,

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -104,12 +104,12 @@ export const json_object = (
  * Create CASE WHEN expression for conditional logic in SQL.
  *
  * ```typescript
- * import { createBuilder, caseWhen } from 'coral-sql'
+ * import { createBuilder, case_when } from 'coral-sql'
  *
  * const [sql, bindings] = createBuilder()
  *   .from('users')
  *   .column(
- *     caseWhen()
+ *     case_when()
  *       .when('status', '=', 'active').then('Active User')
  *       .when('status', '=', 'pending').then('Pending User')
  *       .else('Unknown Status'),
@@ -120,6 +120,6 @@ export const json_object = (
  *
  * @returns ConditionExpressionCaseWhen instance for chaining
  */
-export const caseWhen = (): ConditionExpressionCaseWhen => {
+export const case_when = (): ConditionExpressionCaseWhen => {
   return new ConditionExpressionCaseWhen()
 }


### PR DESCRIPTION
## Summary
**🚨 BREAKING CHANGE**: Function name changed from `caseWhen` to `case_when`

This change updates the function name to follow the snake_case naming convention, consistent with other utility functions in the library like `is_not_null`, `json_array_aggregate`, etc.

## Changes
- ✅ Renamed `caseWhen` function to `case_when`
- ✅ Updated all imports and exports
- ✅ Updated test cases and documentation
- ✅ Removed unused `caseWhen` import from json.spec.ts

## Migration Guide

### Before
```typescript
import { caseWhen } from 'coral-sql'

const query = builder
  .from('users')
  .column(
    caseWhen()
      .when('status', '=', 'active').then('Active')
      .else('Inactive')
  )
```

### After  
```typescript
import { case_when } from 'coral-sql'

const query = builder
  .from('users')
  .column(
    case_when()
      .when('status', '=', 'active').then('Active')
      .else('Inactive')  
  )
```

## Test Results
- ✅ All 15 case_when tests passing
- ✅ TypeScript compilation successful
- ✅ No lint errors
- ✅ Maintains full backward compatibility in functionality

## Benefits
- **Consistent naming**: Aligns with other utility functions (`is_not_null`, `json_array_aggregate`)
- **Better API cohesion**: Uniform snake_case convention across the library  
- **Improved readability**: More predictable naming pattern for users

## Breaking Change Impact
Users will need to update their imports and usage:
- Import statement: `caseWhen` → `case_when`
- Function calls: `caseWhen()` → `case_when()`

🤖 Generated with [Claude Code](https://claude.ai/code)