### PR TITLE
fix: createBuilder now inherits parent builder options

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -165,7 +165,7 @@ export class SQLBuilder implements SQLBuilderPort {
    * @param options Optional SQLBuilderToSQLInputOptions
    */
   createBuilder(options?: SQLBuilderToSQLInputOptions): SQLBuilderPort {
-    return new SQLBuilder(options)
+    return new SQLBuilder({ ...this.options, ...options })
   }
 
   /**


### PR DESCRIPTION
## Summary
- Modified `createBuilder` method to inherit parent options using spread operator
- New builders will inherit `placeholder`, `indent`, `quote`, `driver` settings from parent
- Allows overriding inherited options by passing new options parameter
- Maintains backward compatibility

## 変更内容
以前は`createBuilder()`で作成された新しいbuilderは親のオプションを引き継がず、デフォルト設定になっていました。

```typescript
// 修正前
createBuilder(options?: SQLBuilderToSQLInputOptions): SQLBuilderPort {
  return new SQLBuilder(options)
}

// 修正後  
createBuilder(options?: SQLBuilderToSQLInputOptions): SQLBuilderPort {
  return new SQLBuilder({ ...this.options, ...options })
}
```

## Test plan
- [x] 既存のテストが全て通ることを確認 (186個のテスト全てpass)
- [x] createBuilderのオプション継承が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)