### PR TITLE
feat: add driver-dependent placeholder defaults

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -4,8 +4,8 @@ import { SQLBuilderToSQLInputOptions, SQLBuilderToSQLOptions } from './types'
 export const ensureToSQL = (
   input: SQLBuilderToSQLInputOptions = {}
 ): SQLBuilderToSQLOptions => {
-  const placeholder = input.placeholder ?? '?'
   const driver = input.driver ?? 'mysql'
+  const placeholder = input.placeholder ?? getDefaultPlaceholder(driver)
   const quote = input.quote ?? getDefaultQuote(driver)
   
   const defaults = {
@@ -23,6 +23,17 @@ export const ensureToSQL = (
   }
   
   return result
+}
+
+const getDefaultPlaceholder = (driver: 'mysql' | 'postgresql' | 'sqlite'): '?' | '$' => {
+  switch (driver) {
+    case 'postgresql':
+      return '$'
+    case 'mysql':
+    case 'sqlite':
+    default:
+      return '?'
+  }
 }
 
 const getDefaultQuote = (driver: 'mysql' | 'postgresql' | 'sqlite'): string => {

--- a/src/specs/builder.spec.ts
+++ b/src/specs/builder.spec.ts
@@ -923,6 +923,94 @@ describe('builder', () => {
     })
   })
 
+  describe('driver-dependent defaults', () => {
+    describe('PostgreSQL driver default placeholder', () => {
+      it('uses $ placeholder by default for PostgreSQL', () => {
+        const postgresqlBuilder = new SQLBuilder({ driver: 'postgresql' }) as unknown as SQLBuilderPort
+        const [sql, bindings] = postgresqlBuilder
+          .from('users')
+          .where('id', 1)
+          .toSQL()
+        expect(sql).to.be.eql(
+          'SELECT\n  *\nFROM\n  "users"\nWHERE\n  ("id" = $1)'
+        )
+        expect(bindings).to.be.eql([1])
+      })
+
+      it('uses $ placeholder by default for PostgreSQL with multiple conditions', () => {
+        const postgresqlBuilder = new SQLBuilder({ driver: 'postgresql' }) as unknown as SQLBuilderPort
+        const [sql, bindings] = postgresqlBuilder
+          .from('users')
+          .where('name', 'John')
+          .where('age', '>=', 18)
+          .toSQL()
+        expect(sql).to.be.eql(
+          'SELECT\n  *\nFROM\n  "users"\nWHERE\n  ("name" = $1)\n  AND ("age" >= $2)'
+        )
+        expect(bindings).to.be.eql(['John', 18])
+      })
+    })
+
+    describe('MySQL driver default placeholder', () => {
+      it('uses ? placeholder by default for MySQL', () => {
+        const mysqlBuilder = new SQLBuilder({ driver: 'mysql' }) as unknown as SQLBuilderPort
+        const [sql, bindings] = mysqlBuilder
+          .from('users')
+          .where('id', 1)
+          .toSQL()
+        expect(sql).to.be.eql(
+          'SELECT\n  *\nFROM\n  `users`\nWHERE\n  (`id` = ?)'
+        )
+        expect(bindings).to.be.eql([1])
+      })
+    })
+
+    describe('SQLite driver default placeholder', () => {
+      it('uses ? placeholder by default for SQLite', () => {
+        const sqliteBuilder = new SQLBuilder({ driver: 'sqlite' }) as unknown as SQLBuilderPort
+        const [sql, bindings] = sqliteBuilder
+          .from('users')
+          .where('id', 1)
+          .toSQL()
+        expect(sql).to.be.eql(
+          'SELECT\n  *\nFROM\n  `users`\nWHERE\n  (`id` = ?)'
+        )
+        expect(bindings).to.be.eql([1])
+      })
+    })
+
+    describe('default behavior without driver specified', () => {
+      it('uses ? placeholder by default (MySQL default)', () => {
+        const defaultBuilder = new SQLBuilder() as unknown as SQLBuilderPort
+        const [sql, bindings] = defaultBuilder
+          .from('users')
+          .where('id', 1)
+          .toSQL()
+        expect(sql).to.be.eql(
+          'SELECT\n  *\nFROM\n  `users`\nWHERE\n  (`id` = ?)'
+        )
+        expect(bindings).to.be.eql([1])
+      })
+    })
+
+    describe('explicit placeholder override', () => {
+      it('explicit placeholder setting overrides driver default', () => {
+        const postgresqlBuilder = new SQLBuilder({ 
+          driver: 'postgresql', 
+          placeholder: '?' 
+        }) as unknown as SQLBuilderPort
+        const [sql, bindings] = postgresqlBuilder
+          .from('users')
+          .where('id', 1)
+          .toSQL()
+        expect(sql).to.be.eql(
+          'SELECT\n  *\nFROM\n  "users"\nWHERE\n  ("id" = ?)'
+        )
+        expect(bindings).to.be.eql([1])
+      })
+    })
+  })
+
   describe('instance methods', () => {
     describe('.createBuilder()', () => {
       it('creates a new SQLBuilder instance', () => {


### PR DESCRIPTION
## Summary
- PostgreSQL now uses `$1, $2, ...` placeholders by default
- MySQL and SQLite continue using `?` placeholders as before
- Added comprehensive test coverage for all drivers
- Maintains backward compatibility with explicit placeholder override

## Changes
- Modified `src/options.ts` to implement `getDefaultPlaceholder` function
- Added driver-dependent logic for PostgreSQL (`$`) vs MySQL/SQLite (`?`)
- Added extensive tests in `src/specs/builder.spec.ts` for all scenarios
- All 195 tests pass successfully

## Test plan
- [x] PostgreSQL driver uses `$` placeholders by default
- [x] MySQL driver uses `?` placeholders by default  
- [x] SQLite driver uses `?` placeholders by default
- [x] Default behavior (no driver specified) uses `?` placeholders
- [x] Explicit placeholder setting overrides driver defaults
- [x] All existing functionality remains unchanged
- [x] Full test suite passes (195/195 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)