### PR TITLE
docs: fix .claude/CLAUDE.md drift from implementation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,17 +12,33 @@ passed straight to a driver, e.g. `connection.query(sql, bindings)`.
 import { createBuilder, unescape } from 'coral-sql'
 
 const [sql, bindings] = createBuilder()
-  .columns('age')
-  .columns(unescape('COUNT(*)'), 'value')
+  .column('age')
+  .column(unescape('COUNT(*)'), 'value')
   .from('users')
   .where('enabled', true)
   .groupBy('age')
   .having('value', '>=', 10)
   .orderBy('value', 'desc')
   .toSQL()
-// SELECT `age`, COUNT(*) AS `value` FROM `users` WHERE `enabled` = ? GROUP BY `age` HAVING `value` >= ? ORDER BY `value` DESC
+// sql (formatted, WHERE/HAVING conditions are parenthesized):
+//   SELECT
+//     `age`,
+//     COUNT(*) AS `value`
+//   FROM
+//     `users`
+//   WHERE
+//     (`enabled` = ?)
+//   GROUP BY
+//     `age`
+//   HAVING
+//     (`value` >= ?)
+//   ORDER BY
+//     `value` DESC
 // bindings: [1, 10]
 ```
+
+The method is `.column()` (singular). Output is multi-line and WHERE/HAVING conditions are
+wrapped in parentheses — see `src/specs/builder.spec.ts` for the exact expected strings.
 
 The published npm package name is `coral-sql` (the GitHub repository is `coral-sql-js`).
 
@@ -57,13 +73,16 @@ The big picture lives across `src/index.ts`, `src/builder.ts`, and `src/options.
 
 ### Public contract vs. internals
 
-`src/index.ts` is the only barrel. It re-exports **Port interfaces** (`XxxPort` types) and
-**factory functions** — `createBuilder`, `createConditions`, `unescape`, `exists`/`not_exists`,
-`is_null`/`is_not_null`, `case_when`, `coalesce`, `json_object`, `json_array_aggregate`.
-The implementation classes under `builder/` (`Columns`, `Table`, `Join`, `Condition`, …) are
-**not exported** — they are private. Interfaces are named `XxxPort` and live in `src/types.ts`
-(the single source of truth for all types); the implementing class drops the `Port` suffix
-(`FieldPort` ⇔ `Field`, `BindingsPort` ⇔ `Bindings`).
+`src/index.ts` is the only barrel. It re-exports:
+
+- **Factory functions** — `createBuilder`, `createConditions`, `unescape`, `exists`/`not_exists`,
+  `is_null`/`is_not_null`, `case_when`, `coalesce`, `json_object`, `json_array_aggregate`.
+- **A few implementation classes** — `Field`, `Condition` (as `SQLBuilderCondition`), and
+  `Conditions` (as `SQLBuilderConditions`) are part of the public surface. Most clause classes
+  (`Columns`, `Table`, `Join`, `Groups`, `Orders`, …) stay private.
+- **Port interfaces** (`XxxPort` types) from `src/types.ts`, the single source of truth for all
+  types. A `Port` interface and its implementing class share a name minus the suffix
+  (`FieldPort` ⇔ `Field`, `BindingsPort` ⇔ `Bindings`).
 
 ### SQLBuilder is a composition hub (`src/builder.ts`)
 
@@ -76,11 +95,16 @@ delegates to its collection and returns `this` to chain. `toSQL()` just calls ea
 ### Option propagation via `ensureToSQL()` (`src/options.ts`) — the crux of the design
 
 `ensureToSQL()` normalizes `SQLBuilderToSQLInputOptions` (partial, user-facing) into a resolved
-`SQLBuilderToSQLOptions`. **Every** `toSQL()` implementation calls it first. Crucially, a **single
-`bindings` instance is threaded through the whole tree via the shared `options` object** — child
-components never create their own `Bindings`, they push onto `options.bindings`. This is what keeps
-bind-parameter order consistent across nested subqueries and expressions. If `input.bindings`
-already exists, `ensureToSQL()` reuses it rather than allocating a new one.
+`SQLBuilderToSQLOptions`. Most `toSQL()` implementations call it first to pull out the resolved
+`bindings`/`driver`/`quote`. Some pure pass-through nodes do **not** call it and just forward the
+raw `options` downstream — `Table.toSQL()`, `Join.toSQL()`, and the `EXISTS`/`NOT EXISTS`
+expressions (`src/builder/condition-expression.ts`) delegate straight to the subquery/`escape()`.
+
+Crucially, a **single `bindings` instance is threaded through the whole tree via the shared
+`options` object** — child components never create their own `Bindings`, they push onto
+`options.bindings`. This is what keeps bind-parameter order consistent across nested subqueries
+and expressions. `new Bindings` appears in exactly one place (`src/options.ts`); if
+`input.bindings` already exists, `ensureToSQL()` reuses it rather than allocating a new one.
 
 ### Driver-dependent dialect differences (a common gotcha)
 


### PR DESCRIPTION
## 概要

`.claude/CLAUDE.md` とコード・テストを三者照合（コード実行 / grep / テスト期待値）した結果、CLAUDE.md に **4 件の乖離**があった。すべて実測で確定し、CLAUDE.md 側を修正した。実装とテストの間には乖離なし（両者は一致していた）。

## 修正した乖離（すべて実測で確定）

| # | 乖離 | 確定方法 |
|---|------|---------|
| ① | コード例が `.columns()`（複数形）を呼んでいたが実装に存在しない（`.column()` が正） | 例を実行 → `TypeError`。テストは全て `.column` を使用 |
| ② | SQL 出力コメントが1行・括弧なしだが、実出力は複数行整形・WHERE/HAVING が括弧付き | 例を実行し実出力を確認。`src/specs/builder.spec.ts:53` の期待値と一致 |
| ③ | 「`builder/` の実装クラスは非公開」だが `Field`/`Condition`/`Conditions` は公開されている | `src/index.ts:29,38,43` で export を確認 |
| ④ | 「**全** `toSQL()` が `ensureToSQL` を呼ぶ」は誤り。`Table`/`Join`/`EXISTS`/`NOT EXISTS` は呼ばず生 options を転送 | 各ファイルを grep で確認 |

## 対応内容

- ①② → コード例を `.column` に直し、SQL コメントを実出力に置換。**修正後の例は実出力とバイト単位で一致**することを確認済み
- ③ → 公開クラスと非公開クラスを分けて明記
- ④ → 「多くの `toSQL()` が呼ぶ」に修正し、呼ばない例外を列挙

## スコープ外（補足）

①② の誤りは README.md（24-25行目）由来で、それを CLAUDE.md に引き写したもの。README 本体にも同じ動かないコード例が残っているが、本 PR のスコープ（CLAUDE.md）外とした。README の修正は別途対応。

## 差分

`1 file changed, 39 insertions(+), 15 deletions(-)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)