### PR TITLE
docs: fix broken Usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The nodejs module for building SQL by complec and related like coral.
 ## Usage
 
 ```ts
-import { createBuilder } from 'coral-sql'
+import { createBuilder, unescape } from 'coral-sql'
 
 const [sql, bindings] = createBuilder()
-  .columns('age')
-  .columns(unescape('COUNT(*)'), 'value')
+  .column('age')
+  .column(unescape('COUNT(*)'), 'value')
   .from('users')
   .where('enabled', true)
   .groupBy('age')
@@ -31,8 +31,22 @@ const [sql, bindings] = createBuilder()
   .toSQL()
 
 const query = await connection.query(sql, bindings)
-// SELECT `age`, COUNT(*) AS `value` FROM `users` WHERE `enabled` = ? GROUP BY `age` HAVING `value` >= ? ORDER BY `value` DESC
-// [1, 10]
+
+// sql:
+//   SELECT
+//     `age`,
+//     COUNT(*) AS `value`
+//   FROM
+//     `users`
+//   WHERE
+//     (`enabled` = ?)
+//   GROUP BY
+//     `age`
+//   HAVING
+//     (`value` >= ?)
+//   ORDER BY
+//     `value` DESC
+// bindings: [1, 10]
 ```
 
 ## Documentation


### PR DESCRIPTION
## 概要

README の Usage 例は**実行すると動かず**、出力コメントも実態とずれていた。実測（例を実行し出力をバイト比較）で 3 点の乖離を確定し修正した。

## 修正した乖離

| # | 乖離 | 確定方法 |
|---|------|---------|
| ① | `.columns()`（複数形）は実装に存在せず `TypeError` になる。正しい API は `.column()`（単数形） | 例を実行 → `TypeError`。テスト・実装ともに `.column` |
| ② | コード内で `unescape` を使っているのに import 文に含まれていない（`import { createBuilder }` のみ） | 例をそのまま実行すると `unescape is not defined` |
| ③ | 出力コメントの SQL が1行・括弧なしだが、実出力は複数行整形で WHERE/HAVING 条件が括弧付き | 例を実行し実出力をバイト比較。修正後は完全一致 |

## 検証

修正後のコード例をそのまま実行し、SQL・bindings とも実出力とバイト単位で一致することを確認済み。

## 関連

同じ誤りを引き写していた `.claude/CLAUDE.md` は #30 で修正済み。本 PR はユーザー向け公式ドキュメント（README）側の修正。

## 差分

`1 file changed, 19 insertions(+), 5 deletions(-)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)